### PR TITLE
GET /rateのレスポンスにプール量とliquidityを追加

### DIFF
--- a/packages/backend/calculate.js
+++ b/packages/backend/calculate.js
@@ -74,14 +74,46 @@ const rate = (
     config.amountInUsdc
   );
 
+  const quickSellJpycRate = config.amountInJpyc / quickOutUsdc;
+  const quickBuyJpycRate = quickOutJpyc / config.amountInUsdc;
+  const quickAverageRate = (quickSellJpycRate + quickBuyJpycRate) / 2;
+
+  const sushiSellJpycRate = config.amountInJpyc / sushiOutUsdc;
+  const sushiBuyJpycRate = sushiOutJpyc / config.amountInUsdc;
+  const sushiAverageRate = (sushiSellJpycRate + sushiBuyJpycRate) / 2;
+
   return {
     QUICKSWAP: {
-      sell: config.amountInJpyc / quickOutUsdc,
-      buy: quickOutJpyc / config.amountInUsdc,
+      sell: quickSellJpycRate,
+      buy: quickBuyJpycRate,
+      jpycReserves: strToFloat(
+        address.TOKEN.JPYC.Decimals,
+        quickJpycReserves.toString()
+      ),
+      usdcReserves: strToFloat(
+        address.TOKEN.USDC.Decimals,
+        quickUsdcReserves.toString()
+      ),
+      liquidity:
+        strToFloat(address.TOKEN.JPYC.Decimals, quickJpycReserves.toString()) /
+          sushiAverageRate +
+        strToFloat(address.TOKEN.USDC.Decimals, quickUsdcReserves.toString()),
     },
     SUSHISWAP: {
-      sell: config.amountInJpyc / sushiOutUsdc,
-      buy: sushiOutJpyc / config.amountInUsdc,
+      sell: sushiSellJpycRate,
+      buy: sushiBuyJpycRate,
+      jpycReserves: strToFloat(
+        address.TOKEN.JPYC.Decimals,
+        sushiJpycReserves.toString()
+      ),
+      usdcReserves: strToFloat(
+        address.TOKEN.USDC.Decimals,
+        sushiUsdcReserves.toString()
+      ),
+      liquidity:
+        strToFloat(address.TOKEN.JPYC.Decimals, sushiJpycReserves.toString()) /
+          quickAverageRate +
+        strToFloat(address.TOKEN.USDC.Decimals, sushiUsdcReserves.toString()),
     },
   };
 };

--- a/packages/backend/main.js
+++ b/packages/backend/main.js
@@ -123,14 +123,15 @@ const server = app.listen(3002, () => {
 });
 
 app.get("/rate", (req, res) => {
-  res.send(
-    calFunc.rate(
+  res.send({
+    status: true,
+    body: calFunc.rate(
       quickJpycReserves,
       quickUsdcReserves,
       sushiJpycReserves,
       sushiUsdcReserves
-    )
-  );
+    ),
+  });
 });
 
 app.get("/profit", (req, res) => {


### PR DESCRIPTION
GET /rateでliquidityも取得できるように修正しました。
計算式：
```
liquidity = jpycReserve / rate + usdcReserve
( rate = (sellRate + buyRate) / 2 )
```

また計算式が正しい自信がないので、フロントからでも計算できるようにGET /rateでjpycReserve, usdcReserveも取れるようにしました。